### PR TITLE
Faster __get__

### DIFF
--- a/benchs/simple.py
+++ b/benchs/simple.py
@@ -1,0 +1,27 @@
+import perf
+
+
+from watch import WatchMe, ArrayOf, MappingOf
+from watch.builtins import InstanceOf
+
+
+class MyClass(WatchMe):
+    foo = ArrayOf(MappingOf(InstanceOf(str), InstanceOf(int)))
+
+
+my_obj = MyClass()
+foo = [{'a': 1, 'b': 2, 'c': 3, 'd': 4}]
+my_obj.foo = foo
+
+
+def bench_get():
+    return my_obj.foo
+
+
+def bench_set():
+    my_obj.foo = foo
+
+
+runner = perf.Runner()
+runner.bench_func("__get__", bench_get)
+runner.bench_func("__set__", bench_set)

--- a/benchs/simple.py
+++ b/benchs/simple.py
@@ -22,6 +22,17 @@ def bench_set():
     my_obj.foo = foo
 
 
+my_obj_missing = MyClass()
+
+
+def bench_get_missing():
+    try:
+        my_obj_missing.foo
+    except AttributeError:
+        pass
+
+
 runner = perf.Runner()
 runner.bench_func("__get__", bench_get)
 runner.bench_func("__set__", bench_set)
+runner.bench_func("__get__missing", bench_get_missing)

--- a/watch/attr_controllers.py
+++ b/watch/attr_controllers.py
@@ -15,7 +15,8 @@ class AttributeDescriptor:
 
     def __get__(self, obj, klass=None):
         # when attr being looked up in class instead of instance
-        if klass is not None and obj is None:
+        # klass is always not None
+        if obj is None:
             return self
 
         if self.field_name not in obj.__dict__:

--- a/watch/attr_controllers.py
+++ b/watch/attr_controllers.py
@@ -19,11 +19,12 @@ class AttributeDescriptor:
         if obj is None:
             return self
 
-        if self.field_name not in obj.__dict__:
+        try:
+            return obj.__dict__[self.field_name]
+        except KeyError:
             raise AttributeError(
                 "Object %s has no attribute '%s'." % (obj, self.field_name)
             )
-        return obj.__dict__[self.field_name]
 
     def __set__(self, obj, value):
         obj.__dict__[self.field_name] = value


### PR DESCRIPTION
Benchmarks:

```
+-----------+----------+------------------------------+
| Benchmark | baseline | keyerror                     |
+===========+==========+==============================+
| __get__   | 891 ns   | 646 ns: 1.38x faster (-27%)  |
+-----------+----------+------------------------------+
| __set__   | 28.4 us  | 23.7 us: 1.20x faster (-17%) |
+-----------+----------+------------------------------+
```